### PR TITLE
Link to GitHub help pages for terms in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A great example repo you can fork to your heart’s content, that serves as a la
 
 ## Getting started
 
-The first thing you want to do with this repo is quite likely **fork it**.  Use the Fork button in the top-right section of the page to do this.
+The first thing you want to do with this repo is quite likely [**fork it**](https://help.github.com/articles/fork-a-repo/).  Use the Fork button in the top-right section of the page to do this.
 
 Once you’re on your fork, you can experiment however you like with it, play with branches, issues, milestones, labels, the wiki, and more.
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,12 @@ A great example repo you can fork to your heart’s content, that serves as a la
 
 The first thing you want to do with this repo is quite likely [**fork it**](https://help.github.com/articles/fork-a-repo/).  Use the Fork button in the top-right section of the page to do this.
 
-Once you’re on your fork, you can experiment however you like with it, play with branches, issues, milestones, labels, the wiki, and more.
+Once you’re on your fork, you can experiment however you like with it, play with 
+[branches](https://www.google.be/?gws_rd=ssl), 
+[issues](https://www.google.be/?gws_rd=ssl), 
+[milestones](https://www.google.be/?gws_rd=ssl), 
+[labels](https://www.google.be/?gws_rd=ssl), the 
+[wiki](https://www.google.be/?gws_rd=ssl), and more.
 
 ## What’s in there?
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Once you’re on your fork, you can experiment however you like with it, play wi
 
 ## What’s in there?
 
-Various files to support upcoming GitHub tasks the series trains you for, but more importantly, demonstration out-of-codebase contents (e.g. issues and milestones) so you can get a feeling of what features GitHub offers without having to first create such content or data.  The video series frequently uses this repository as a way of touring trainees briefly through these features before tackling them.
+Various files to support upcoming GitHub tasks the series trains you for, but more importantly, demonstration out-of-codebase contents (e.g. issues and milestones) so you can get a feeling of what features GitHub offers without having to first create such content or data.  The video series frequently uses this repository as a way of [touring trainees](https://www.google.be/?gws_rd=ssl) briefly through these features before tackling them.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A great example repo you can fork to your heart’s content, that serves as a la
 The first thing you want to do with this repo is quite likely [**fork it**](https://help.github.com/articles/fork-a-repo/).  Use the Fork button in the top-right section of the page to do this.
 
 Once you’re on your fork, you can experiment however you like with it, play with 
-[branches](https://www.google.be/?gws_rd=ssl), 
+[branches](http://deredactie.be/cm/vrtnieuws), 
 [issues](https://www.google.be/?gws_rd=ssl), 
 [milestones](https://www.google.be/?gws_rd=ssl), 
 [labels](https://www.google.be/?gws_rd=ssl), the 


### PR DESCRIPTION
The README stresses that this repo is intended for forks, but GitHub newbies
may have no idea what these are about, so we link to the official docs!

We provide even more links to GitHub help for newbies: branch management, issues, milestones, labels and wikis.